### PR TITLE
Enable call wrapping

### DIFF
--- a/resque.go
+++ b/resque.go
@@ -10,16 +10,14 @@ import (
 
 var drivers = make(map[string]driver.Enqueuer)
 
-type jobArg interface{}
-
 type MockRedisDriver struct {
 	driver.Enqueuer
 }
 
 type job struct {
-	Queue string   `json:"queue,omitempty"`
-	Class string   `json:"class"`
-	Args  []jobArg `json:"args"`
+	Queue string        `json:"queue,omitempty"`
+	Class string        `json:"class"`
+	Args  []interface{} `json:"args"`
 }
 
 func Register(name string, driver driver.Enqueuer) {
@@ -44,10 +42,10 @@ type RedisEnqueuer struct {
 	drv driver.Enqueuer
 }
 
-func (enqueuer *RedisEnqueuer) Enqueue(ctx context.Context, queue, jobClass string, args ...jobArg) (int64, error) {
+func (enqueuer *RedisEnqueuer) Enqueue(ctx context.Context, queue, jobClass string, args ...interface{}) (int64, error) {
 	// NOTE: Dirty hack to make a [{}] JSON struct
 	if len(args) == 0 {
-		args = append(make([]jobArg, 0), make(map[string]jobArg, 0))
+		args = append(make([]interface{}, 0), make(map[string]interface{}, 0))
 	}
 
 	jobJSON, err := json.Marshal(&job{Class: jobClass, Args: args})
@@ -59,11 +57,11 @@ func (enqueuer *RedisEnqueuer) Enqueue(ctx context.Context, queue, jobClass stri
 }
 
 // EnqueueIn enque a job at a duration
-func (enqueuer *RedisEnqueuer) EnqueueIn(ctx context.Context, delay time.Duration, queue, jobClass string, args ...jobArg) (bool, error) {
+func (enqueuer *RedisEnqueuer) EnqueueIn(ctx context.Context, delay time.Duration, queue, jobClass string, args ...interface{}) (bool, error) {
 	enqueueTime := time.Now().Add(delay)
 
 	if len(args) == 0 {
-		args = append(make([]jobArg, 0), make(map[string]jobArg, 0))
+		args = append(make([]interface{}, 0), make(map[string]interface{}, 0))
 	}
 
 	jobJSON, err := json.Marshal(&job{Class: jobClass, Args: args, Queue: queue})


### PR DESCRIPTION
Say, I want to create a wrapper for `Enqueue` from this lib in my client code. For example, in my case each queue consist of only single type of tasks, so there is no need to have a class and I decided to create a wrapper that will just set an empty string as a class:
```
func Enqueue(ctx context.Context, queue string, args ...interface{}) (int64, error) {
    // enqueuer is an instance of go-resque created elsewhere
    return enqueuer.Enqueue(ctx, queue, "", args...)
}
```

But this is not possible to do, because `args` in go-resque's `Enqueue` call has to be of type `jobArg`. Since this is a private type, I can't cast to it or use it in any other way.  
Moreover, this type is just a synonym for `interface{}` with no additional meaning or functionality.  
So I'm not sure what is the point of having it in the first place.

This PR get rid of this custom type in favor of `interface{}`